### PR TITLE
fix build process

### DIFF
--- a/.github/workflows/build_icons.yml
+++ b/.github/workflows/build_icons.yml
@@ -42,8 +42,8 @@ jobs:
         if: ${{ success() }}
         uses: peter-evans/create-pull-request@v3
         with:
-          branch: ${{ format('build/{0}', github.head_ref) }}
-          base: 'develop'
+          branch: 'master-build-result'
+          base: 'master'
           commit-message: 'Built new icons, icomoon.json and devicon.css'
           title: 'bot:build new icons, icomoon.json and devicon.css'
           body: 'Automated font-building task ran by GitHub Actions bot'


### PR DESCRIPTION
Currently our font build process fail since it's not ready for `workflow_dispatch` trigger:

![image](https://user-images.githubusercontent.com/8781699/101054172-e6dd0180-3588-11eb-80db-19d3e3ad6c98.png)

Since we are only triggering this action manually when a new release should be made we need to specify a fixed name for the resulting branch and can set the base to our master branch.