### PR TITLE
fix github font version and add alias (solves #373)

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -1105,12 +1105,17 @@
                 "original-wordmark"
             ],
             "font": [
-                "plain",
-                "plain-wordmark"
+                "original",
+                "original-wordmark"
             ]
         },
         "color": "#181616",
-        "aliases": []
+        "aliases": [
+            {
+                "base": "original",
+                "alias": "plain"
+            }
+        ]
     },
     {
         "name": "gitlab",


### PR DESCRIPTION
as reported in issue #373 github font is saved as original but the devicon.json is referencing the non-existing plain version