### PR TITLE
Fixed an error with devicon.json

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -2670,14 +2670,15 @@
                 "plain"
             ],
             "font": [
-                "plain"
+                "plain",
+                "original-wordmark"
             ]
         },
         "color": "#333333",
         "aliases": [
           {
             "base": "original-wordmark",
-            "alias": "plain-wordmark",
+            "alias": "plain-wordmark"
           }
         ]
     },


### PR DESCRIPTION
There was an error with the sqlalchemy entry in the `devicon.json`. One of them involved putting the incorrect value into the `font` attribute. This was on me since I didn't explain it enough so I just fixed it.