### PR TITLE
add environment for npm publish workflow

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,6 +3,7 @@ on:
     types: [released]
 jobs:
   publish:
+    environment: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I tried to work with https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idenvironment in the `npm_publish` workflow. This pull request will hopefully fix the workflow for the next release ;-) This time I will publish to npm by hand.