### PR TITLE
Fix the issue with "Post Check SVG" posting the wrong message

### DIFF
--- a/.github/workflows/post_check_svgs_comment.yml
+++ b/.github/workflows/post_check_svgs_comment.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Comment on the PR about the result - SVG Error
         uses: jungwinter/comment@v1 # let us comment on a specific PR
-        if: success() && (steps.err_message_reader.outputs.content != '0' || steps.err_message_reader.outputs.content != '1')
+        if: success() && (steps.err_message_reader.outputs.content != '0' && steps.err_message_reader.outputs.content != '1')
         env:
           MESSAGE: |
             Hi!


### PR DESCRIPTION
I think I figure out the issue.

Here's what we want the bot to do:
Post a failure message if value is a text. This means the code is not `1` aka `SVG_STATUS_CODE.SVG_OK` or `0` aka `SVG_STATUS_CODE.NO_SVG`

Here's what the old check is:
```
(steps.err_message_reader.outputs.content != '0' || steps.err_message_reader.outputs.content != '1')
```
However, this would be interpreted differently by the script. If the `error_message` is `1`, it will trip the first check. If the `error_message` is `0`, it will trip the second cause OR operators check terms until one is true. 

Pretty much, this is the wrong check. Using OR in human language is different than OR in computer and I forgot to "translate" it.

Here's the new check: 
```
(steps.err_message_reader.outputs.content != '0' && steps.err_message_reader.outputs.content != '1')
```
This will ensure that only contents that don't match both `0` and `1` trigger the script. 

This should work.