### PR TITLE
Fix issue with "post_peek_screenshot" action failing when it's not supposed to

### DIFF
--- a/.github/workflows/peek_icons.yml
+++ b/.github/workflows/peek_icons.yml
@@ -3,7 +3,10 @@ on:
   pull_request:
       types: [labeled]
 jobs:
-  build:
+  peek:
+    # four outcomes: successful check and upload,
+    # unsuccessful check (fail due to user),
+    # fail due to system, skipped
     name: Peek Icons
     if: github.event.label.name == 'bot:peek'
     runs-on: windows-2019
@@ -20,6 +23,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r ./.github/scripts/requirements.txt
 
+      - name: Save the pr num in an artifact
+        shell: bash
+        env:
+          PR_NUM: ${{ github.event.number }}
+        run: echo $PR_NUM > pr_num.txt
+
+      - name: Upload the pr num
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr_num
+          path: ./pr_num.txt
+
       - name: Run icomoon_peek.py
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -35,18 +50,6 @@ jobs:
         with:
           name: screenshots
           path: ./screenshots/*.png
-
-      - name: Save the pr num in an artifact
-        shell: bash
-        env:
-          PR_NUM: ${{ github.event.number }}
-        run: echo $PR_NUM > pr_num.txt
-
-      - name: Upload the pr num
-        uses: actions/upload-artifact@v2
-        with:
-          name: pr_num
-          path: ./pr_num.txt
 
       - name: Upload geckodriver.log for debugging purposes
         uses: actions/upload-artifact@v2

--- a/.github/workflows/peek_icons.yml
+++ b/.github/workflows/peek_icons.yml
@@ -23,13 +23,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r ./.github/scripts/requirements.txt
 
-      - name: Save the pr num in an artifact
+      - name: Save the PR number in an artifact
         shell: bash
         env:
           PR_NUM: ${{ github.event.number }}
         run: echo $PR_NUM > pr_num.txt
 
-      - name: Upload the pr num
+      - name: Upload the PR number
         uses: actions/upload-artifact@v2
         with:
           name: pr_num

--- a/.github/workflows/post_check_svgs_comment.yml
+++ b/.github/workflows/post_check_svgs_comment.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Comment on the PR about the result - SVG Error
         uses: jungwinter/comment@v1 # let us comment on a specific PR
-        if: success() && (steps.err_message_reader.outputs.content != '0' || steps.err_message_reader.outputs.content != '1')
+        if: success() && (steps.err_message_reader.outputs.content != '0' && steps.err_message_reader.outputs.content != '1')
         env:
           MESSAGE: |
             Hi!

--- a/.github/workflows/post_peek_screenshot.yml
+++ b/.github/workflows/post_peek_screenshot.yml
@@ -8,10 +8,17 @@ jobs:
   post_screenshots_in_comment:
     name: Post the screenshot
     runs-on: ubuntu-18.04
-    if: github.event.action == 'completed'
-    env:
-      STATUS_SUCCEED: github.event.workflow_run.conclusion == 'success' 
+    if: github.event.action == 'completed' && github.event.workflow_run.conclusion != 'skipped'
+    env: 
+      # three possible values: 'skipped', 'success', 'failure'
+      # have to print github.event to console to see these values
+      # note: can't use this env variable up in the if statement above for some reason.
+      # I don't think it's an ordering issue cause it seems 'if' is auto evaluate first
+      PEEK_STATUS: ${{ github.event.workflow_run.conclusion }}
     steps:
+      - name: Check state of last run
+        run: echo $PEEK_STATUS
+
       - name: Download workflow artifact
         uses: dawidd6/action-download-artifact@v2.11.0
         with:
@@ -27,7 +34,7 @@ jobs:
 
       - name: Upload screenshot of the newly made icons gotten from the artifacts
         id: icons_overview_img_step
-        if: env.STATUS_SUCCEED
+        if: env.PEEK_STATUS == 'success' && success()
         uses: devicons/public-upload-to-imgur@v2.2.1
         with:
           path: ./screenshots/new_icons.png
@@ -36,17 +43,15 @@ jobs:
       - name: Upload zoomed in screenshot of the newly made icons gotten from the artifacts 
         id: icons_detailed_img_step
         uses: devicons/public-upload-to-imgur@v2.2.1
-        if: env.STATUS_SUCCEED
+        if: env.PEEK_STATUS == 'success' && success()
         with:
           path: ./screenshots/screenshot_*.png
           client_id: ${{secrets.IMGUR_CLIENT_ID}}
 
       - name: Comment on the PR about the result - Success
         uses: jungwinter/comment@v1 # let us comment on a specific PR
-        if: success() && env.STATUS_SUCCEED
+        if: env.PEEK_STATUS == 'success' && success()
         env:
-          OVERVIEW_IMG_MARKDOWN: ${{ fromJSON(steps.icons_overview_img_step.outputs.markdown_urls)[0] }}
-          DETAILED_IMGS_MARKDOWN: ${{ join(fromJSON(steps.icons_detailed_img_step.outputs.markdown_urls), '') }}
           MESSAGE: |
             Hi there,
 
@@ -70,10 +75,13 @@ jobs:
           type: create
           issue_number: ${{ steps.pr_num_reader.outputs.content }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          body: ${{format(env.MESSAGE, env.OVERVIEW_IMG_MARKDOWN, env.DETAILED_IMGS_MARKDOWN)}}
+          body: >
+            ${{ format(env.MESSAGE, 
+            fromJSON(steps.icons_overview_img_step.outputs.markdown_urls)[0],
+            join(fromJSON(steps.icons_detailed_img_step.outputs.markdown_urls), '')) }}
 
       - name: Comment on the PR about the result - Failure
-        if: failure() || !env.STATUS_SUCCEED
+        if: failure() || env.PEEK_STATUS == 'failure'
         uses: jungwinter/comment@v1 # let us comment on a specific PR
         env:
           MESSAGE: |
@@ -87,7 +95,7 @@ jobs:
             - Your icon information has been added to the `devicon.json` as seen [here](https://github.com/devicons/devicon/blob/master/CONTRIBUTING.md#updateDevicon)
             - Your PR title follows the format seen [here](https://github.com/devicons/devicon/blob/master/CONTRIBUTING.md#overview)
 
-            Once everything is fixed, I will try. If I still fail (sorry!), the maintainers will investigate further. 
+            I will retry once everything is fixed. If I still fail (sorry!) or there are other erros, the maintainers will investigate. 
 
             Best of luck, 
             Peek Bot :relaxed:

--- a/.github/workflows/post_peek_screenshot.yml
+++ b/.github/workflows/post_peek_screenshot.yml
@@ -8,11 +8,10 @@ jobs:
   post_screenshots_in_comment:
     name: Post the screenshot
     runs-on: ubuntu-18.04
+    if: github.event.action == 'completed'
+    env:
+      STATUS_SUCCEED: github.event.workflow_run.conclusion == 'success' 
     steps:
-      - name: Check if the trigger run worked. If not, fail the current run.
-        if: github.event.workflow_run.conclusion != 'success'
-        uses: cutenode/action-always-fail@v1.0.1
-
       - name: Download workflow artifact
         uses: dawidd6/action-download-artifact@v2.11.0
         with:
@@ -21,7 +20,6 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
 
       - name: Read the pr_num file
-        if: success()
         id: pr_num_reader
         uses: juliangruber/read-file-action@v1.0.0
         with:
@@ -29,6 +27,7 @@ jobs:
 
       - name: Upload screenshot of the newly made icons gotten from the artifacts
         id: icons_overview_img_step
+        if: env.STATUS_SUCCEED
         uses: devicons/public-upload-to-imgur@v2.2.1
         with:
           path: ./screenshots/new_icons.png
@@ -37,14 +36,14 @@ jobs:
       - name: Upload zoomed in screenshot of the newly made icons gotten from the artifacts 
         id: icons_detailed_img_step
         uses: devicons/public-upload-to-imgur@v2.2.1
-        if: success()
+        if: env.STATUS_SUCCEED
         with:
           path: ./screenshots/screenshot_*.png
           client_id: ${{secrets.IMGUR_CLIENT_ID}}
 
       - name: Comment on the PR about the result - Success
         uses: jungwinter/comment@v1 # let us comment on a specific PR
-        if: success()
+        if: success() && env.STATUS_SUCCEED
         env:
           OVERVIEW_IMG_MARKDOWN: ${{ fromJSON(steps.icons_overview_img_step.outputs.markdown_urls)[0] }}
           DETAILED_IMGS_MARKDOWN: ${{ join(fromJSON(steps.icons_detailed_img_step.outputs.markdown_urls), '') }}
@@ -74,7 +73,7 @@ jobs:
           body: ${{format(env.MESSAGE, env.OVERVIEW_IMG_MARKDOWN, env.DETAILED_IMGS_MARKDOWN)}}
 
       - name: Comment on the PR about the result - Failure
-        if: failure()  || cancelled()
+        if: failure() || !env.STATUS_SUCCEED
         uses: jungwinter/comment@v1 # let us comment on a specific PR
         env:
           MESSAGE: |


### PR DESCRIPTION
This PR should fix the issue mentioned in #514 .

What's new:
The "post_peek_screenshot" will now check for three different states of the trigger "peek_icons" action: "skipped", "success", and "failure. These values have to be found by console logging the `github.event` object. The docs don't mention this for some reason.

![image](https://user-images.githubusercontent.com/43018778/109050746-990afd80-768e-11eb-9169-86b470997f50.png)

Also, GitHub Actions will construct env variables before an if check by default:
![image](https://user-images.githubusercontent.com/43018778/109050846-b9d35300-768e-11eb-8497-bd0c8bf1d002.png)

Before, there was an env variable that relies on a skipped step => script was failing since it couldn't construct this variable.

That's pretty much it. I've tested it using my forked branch. The behaviours are:
- If "peek_icons" was skipped (label incorrect), the "post_peek_action" would also skip
- If "peek_icons" was successful, the "post_peek_action" would post successful message
- If "peek_icons" failed (either due to user or system error), the "post_peek_action" would post failure message. It'll be up to us to find what's wrong. 

I thought about separating user and system error but I don't think it's worth it.  It'll require some extra code and the benefit (in my opinion) is not worth it. If I was to do it, it'll be something like the check SVG workflow.

Let me know what you think
