### PR TITLE
fix: Alerts reported by Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1739,7 +1739,7 @@
             "replace-homedir": "^1.0.0",
             "semver-greatest-satisfied-range": "^1.1.0",
             "v8flags": "^3.2.0",
-            "yargs": "^7.1.0"
+            "yargs": "^13.3.2"
           }
         }
       }
@@ -3528,12 +3528,12 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
+            "yargs-parser": "^18.1.2"
           }
         },
         "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "version": "18.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
@@ -4514,8 +4514,8 @@
       "dev": true
     },
     "yargs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
       "dev": true,
       "requires": {
@@ -4531,12 +4531,12 @@
         "string-width": "^1.0.2",
         "which-module": "^1.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "5.0.0-security.0"
+        "yargs-parser": ">=18.1.2"
       }
     },
     "yargs-parser": {
-      "version": "5.0.0-security.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
       "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Things added/changed:

- Fix alerts reported by [Dependabot](https://github.com/devicons/devicon/security/dependabot/package-lock.json/yargs-parser/open).
  - The `integrity` keys may need to be modified.
