### PR TITLE
Fix link reference in `.github/scripts/icomoon_peek.py`

### DIFF
--- a/.github/scripts/icomoon_peek.py
+++ b/.github/scripts/icomoon_peek.py
@@ -24,7 +24,7 @@ def main():
     if len(filtered_icons) == 0:
         message = "No icons found matching the icon name in the PR's title.\n" \
         "Ensure that a new icon entry is added in the devicon.json and the PR title matches the convention here: \n" \
-        "https://github.com/devicons/devicon/blob/master/CONTRIBUTING.md#overview.\n" \
+        "https://github.com/devicons/devicon/blob/master/CONTRIBUTING.md#overview\n" \
         "Ending script...\n"
         sys.exit(message)
 


### PR DESCRIPTION
Things added/changed:

- Fix link reference in `.github/scripts/icomoon_peek.py` when the build fails.
