### PR TITLE
new icon: rstudio (original, plain)

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -2997,6 +2997,16 @@
         "aliases": []
     },
     {
+        "name": "rstudio",
+        "tags": ["editor", "package", "statistics"],
+        "versions": {
+          "svg": ["original", "plain"],
+          "font": ["plain"]
+        },
+        "color": "#75aadb",
+        "aliases": []
+    },
+    {
         "name": "sass",
         "tags": [
             "pre-processor",

--- a/icons/rstudio/rstudio-original.svg
+++ b/icons/rstudio/rstudio-original.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 128 128"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="rstudio-original.svg"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="748"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="3.2040776"
+     inkscape:cx="36.895331"
+     inkscape:cy="35.722078"
+     inkscape:window-x="-6"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0" />
+  <path
+     fill="#0053CC"
+     d="M71.4,38.8c-1.5-0.6-3.9-1-6.9-1.1c-4.2-0.1-9,0.4-9.2,0.5v20c13.3,0.6,15.5-1.7,15.5-1.7C82.4,50.6,75.1,40.3,71.4,38.8z"
+     id="path2"
+     style="fill:#75aadb;fill-opacity:1" />
+  <path
+     fill="#0053CC"
+     d="M64,0C28.6,0,0,28.6,0,64s28.6,64,64,64s64-28.6,64-64S99.3,0,64,0z M92.6,89.8H82L64.4,63.5h-9V84h9v5.8H41.5v-5.7l7.6-0.1L49,38.1c-0.8-0.2-7.5-0.8-7.5-0.8V32c1,1,7.9,1.2,7.9,1.2c1.6,0.1,3.9,0.2,5.2-0.1c9.3-1.7,16.4-0.4,16.4-0.4c14,3.2,14.2,15.8,10.3,22.6C77.8,61.1,71,62.5,71,62.5l14.4,21.8l7.2-0.1L92.6,89.8L92.6,89.8z"
+     id="path4"
+     style="fill:#75aadb;fill-opacity:1" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.788;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 41.594545,87.07318 v -2.725912 l 1.82069,-0.141732 c 1.001379,-0.07795 2.689655,-0.142327 3.751724,-0.143055 l 1.931035,-0.0013 V 61.029086 37.997015 l -0.937931,-0.126553 c -0.515862,-0.06961 -2.204138,-0.248432 -3.751724,-0.397395 l -2.813794,-0.270841 v -2.509333 c 0,-2.331657 0.02764,-2.49454 0.390374,-2.300411 1.582794,0.847086 10.700721,1.071021 15.830316,0.388791 4.201315,-0.55877 11.494965,-0.425591 14.034403,0.256262 5.483291,1.472293 9.110317,4.646579 10.824354,9.473213 0.716683,2.01814 0.817454,5.847261 0.21643,8.223985 -0.903237,3.571815 -2.390537,6.048253 -4.865523,8.10136 -1.481754,1.229177 -4.846523,3.030402 -6.145291,3.28969 -0.397007,0.07926 -0.771226,0.224031 -0.831598,0.321711 -0.06037,0.09768 3.123158,5.071724 7.074507,11.053429 l 7.184271,10.875824 3.633534,-0.0677 3.633534,-0.06771 v 2.778878 2.778878 l -5.241379,-0.0077 -5.24138,-0.0077 L 73.272908,76.550037 64.454721,63.316382 H 59.866012 55.277304 V 73.688796 84.06121 h 4.524138 4.524138 v 2.868965 2.868966 H 52.960063 41.594545 Z M 66.753166,57.911366 c 3.476129,-0.551257 7.265084,-2.774107 8.97248,-5.263855 2.51138,-3.662122 1.537382,-8.989102 -2.293992,-12.546274 -1.356365,-1.259293 -2.204475,-1.631009 -4.793438,-2.100908 -2.124703,-0.385635 -8.660943,-0.453431 -11.70574,-0.121416 l -1.544827,0.168453 -0.05739,10.082403 -0.05739,10.082403 0.719458,0.105678 c 1.367056,0.200794 8.67129,-0.07512 10.760837,-0.406484 z"
+     id="path839" />
+</svg>

--- a/icons/rstudio/rstudio-plain.svg
+++ b/icons/rstudio/rstudio-plain.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 128 128"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="rstudio-plain.svg"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="748"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="2.265625"
+     inkscape:cx="24.31984"
+     inkscape:cy="64.266436"
+     inkscape:window-x="-6"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     fill="#0053CC"
+     d="M71.4,38.8c-1.5-0.6-3.9-1-6.9-1.1c-4.2-0.1-9,0.4-9.2,0.5v20c13.3,0.6,15.5-1.7,15.5-1.7C82.4,50.6,75.1,40.3,71.4,38.8z"
+     id="path2"
+     style="fill:#75aadb;fill-opacity:1" />
+  <path
+     fill="#0053CC"
+     d="M64,0C28.6,0,0,28.6,0,64s28.6,64,64,64s64-28.6,64-64S99.3,0,64,0z M92.6,89.8H82L64.4,63.5h-9V84h9v5.8H41.5v-5.7l7.6-0.1L49,38.1c-0.8-0.2-7.5-0.8-7.5-0.8V32c1,1,7.9,1.2,7.9,1.2c1.6,0.1,3.9,0.2,5.2-0.1c9.3-1.7,16.4-0.4,16.4-0.4c14,3.2,14.2,15.8,10.3,22.6C77.8,61.1,71,62.5,71,62.5l14.4,21.8l7.2-0.1L92.6,89.8L92.6,89.8z"
+     id="path4"
+     style="fill:#75aadb;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
Taken from #116. Work was done by @Pmz64. I modified the plain version to get the original version.