### PR TITLE
Remove new_icons from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ node_modules
 geckodriver.log
 __pycache__
 *.pyc
+
+
+# DO NOT ADD THE FOLLOWING FILES TO THE GITIGNORE
+# new_icons.png - this is used by peek bot
+# screenshots/ - this is used by build bot

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 geckodriver.log
 __pycache__
 *.pyc
-new_icons.png


### PR DESCRIPTION
This is preventing the `peek-comment` bot from functioning properly.

@amacado or @Panquesito7 please merge this PR first then update the develop branch of each other PR. Currently, those branches cannot finish the peek task and the fix in here will address that. Then, all you have to do is re-apply the `bot:peek` label.