### PR TITLE
Add extra requirement in new icon pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/new_icon.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_icon.md
@@ -7,3 +7,7 @@
 - [] A new object is added in the `devicon.json` file as seen [here](https://github.com/devicons/devicon/blob/develop/CONTRIBUTING.md#-updating-the-deviconjson-)
 
 Refer to the [`CONTRIBUTING.md`](https://github.com/devicons/devicon/blob/develop/CONTRIBUTING.md#contributing-to-devicon) for more details.
+
+
+**Link to official page to prove your SVG is correct and update to date**
+*Link goes here*

--- a/.github/PULL_REQUEST_TEMPLATE/new_icon.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_icon.md
@@ -10,4 +10,5 @@ Refer to the [`CONTRIBUTING.md`](https://github.com/devicons/devicon/blob/develo
 
 
 **Link to official page to prove your SVG is correct and update to date**
+
 *Link goes here*


### PR DESCRIPTION
This occurs to me while I was working on the stale PRs. This is to ensure the SVGs are up to date when it is submitted into the repo.