### PR TITLE
Fix duplicated past icons in build process

### DIFF
--- a/.github/scripts/icomoon_build.py
+++ b/.github/scripts/icomoon_build.py
@@ -67,7 +67,8 @@ def get_icons_for_building(devicon_json_path: str, token: str):
     for pull_req in pull_reqs:
         if api_handler.is_feature_icon(pull_req):
             filtered_icon = util.find_object_added_in_this_pr(all_icons, pull_req["title"])
-            new_icons.append(filtered_icon)
+            if filtered_icon not in new_icons:
+                new_icons.append(filtered_icon)
     return new_icons
 
 


### PR DESCRIPTION
Before, the bot will parse the PR titles and find the corresponding font object in the `devicon.json` without any checks. Thus, this causes an error when the `tailwindcss` was added in two separated PR.

![image](https://user-images.githubusercontent.com/43018778/121822387-c4bcee00-cc53-11eb-8524-b183877f0ff5.png)
![image](https://user-images.githubusercontent.com/43018778/121822411-d2727380-cc53-11eb-8d57-b556329c15a1.png)

![image](https://user-images.githubusercontent.com/43018778/121822424-e1592600-cc53-11eb-987f-3a2bd6a3e440.png)

Fix:
The bot will now ensure the `devicon.json` object is unique within the build list.