### PR TITLE
Fixed issue with wrong name referencing from github api

### DIFF
--- a/.github/scripts/build_assets/api_handler.py
+++ b/.github/scripts/build_assets/api_handler.py
@@ -63,7 +63,13 @@ def find_all_authors(pull_req_data, token):
     commits = response.json()
     authors = set()  # want unique authors only
     for commit in commits:
-        authors.add(commit["commit"]["author"]["name"]) 
+        try:
+            # this contains proper referenceable github name
+            authors.add(commit["author"]["login"]) 
+        except TypeError:
+            # special case
+            authors.add(commit["commit"]["author"]["name"]) 
+            print(f"This URL didn't have an `author` attribute: {pull_req_data['commits_url']}")
     return ", ".join(["@" + author for author in list(authors)])
 
 


### PR DESCRIPTION
GitHub API has some none-standard attributes. Originally, I use this, which has the proper name:
![image](https://user-images.githubusercontent.com/43018778/121823850-aad3d900-cc5c-11eb-8dcc-b6e15926526f.png)

However, sometimes GitHub will reveal the actual user's name, which makes it impossible to reference using the `@` character (see #676)

![image](https://user-images.githubusercontent.com/43018778/121823881-e40c4900-cc5c-11eb-966c-2bd1c0a4f5de.png)

And weirder still, there is another field that contains the proper GitHub name that can be tagged using the `@`. However, not all PRs have it:

Proper:
![image](https://user-images.githubusercontent.com/43018778/121823906-1158f700-cc5d-11eb-817d-9bf93597aaba.png)

Bug:
![image](https://user-images.githubusercontent.com/43018778/121823911-1c138c00-cc5d-11eb-89ab-359ae16efef8.png)

**FIX**
Use the proper `[author][login]` name. If there's an error, use the non-consistent `[commit][author][name]`
