### PR TITLE
Only build script will need token API

### DIFF
--- a/.github/scripts/build_assets/arg_getters.py
+++ b/.github/scripts/build_assets/arg_getters.py
@@ -33,13 +33,13 @@ def get_selenium_runner_args(peek_mode=False):
                         help="The download destination of the Icomoon files",
                         action=PathResolverAction)
 
-    parser.add_argument("token",
-                        help="The GitHub token to access the GitHub REST API.",
-                        type=str)
-
     if peek_mode:
         parser.add_argument("--pr_title",
                             help="The title of the PR that we are peeking at")
+    else:
+        parser.add_argument("token",
+                            help="The GitHub token to access the GitHub REST API.",
+                            type=str)
 
     return parser.parse_args()
 

--- a/.github/scripts/icomoon_peek.py
+++ b/.github/scripts/icomoon_peek.py
@@ -13,7 +13,7 @@ from build_assets import util
 def main():
     runner = None
     try:
-        args = arg_getters.get_selenium_runner_args(True)
+        args = arg_getters.get_selenium_runner_args(peek_mode=True)
         new_icons = filehandler.get_json_file_content(args.devicon_json_path)
 
         # get only the icon object that has the name matching the pr title


### PR DESCRIPTION
This fixes the issue seen in #691 with the peek bot.

Issue:
- The script failed because the script requires a `token` command line arguments. However, peek bot does no need them.

Reason:
- The build bot and peek bot share most of the same command line arguments. One of them, the `token`, was recently added and was meant for build bot only. However, I forgot to enforce that by accident.
- The fix uses an existing check to ensure only the build bot requires the token