### PR TITLE
Publish to npm name

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,3 +1,4 @@
+name: "Publish to npm"
 on:
   release:
     types: [released]


### PR DESCRIPTION
The workflow for publish to npm doesn't have a 
```yml 
name: 
```
so I added it