### PR TITLE
Remove aliases in the OpenGL icon as they're not needed

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -3005,12 +3005,7 @@
             ]
         },
         "color": "#5586a4",
-        "aliases": [
-            {
-                "base": "original",
-                "alias": "plain"
-            }
-        ]
+        "aliases": []
     },
     {
         "name": "oracle",


### PR DESCRIPTION
Things added/changed:

- Remove aliases in the OpenGL icon as they're not needed.
