### PR TITLE
new icon: clojurescript (plain)

### DIFF
--- a/icons/clojurescript/clojurescript-plain.svg
+++ b/icons/clojurescript/clojurescript-plain.svg
@@ -1,1 +1,67 @@
-<svg viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg"><g fill="#96CA4B"><path d="M35.563 79.748c-3.83 0-6.724-1.118-8.714-3.355-1.99-2.237-2.985-5.44-2.985-9.612 0-4.262 1.025-7.527 3.106-9.824 2.08-2.297 5.065-3.446 9.015-3.446 2.653 0 5.065.484 7.176 1.481l-1.628 4.323c-2.262-.877-4.131-1.33-5.608-1.33-4.372 0-6.543 2.902-6.543 8.705 0 2.841.543 4.957 1.628 6.408 1.085 1.42 2.683 2.146 4.794 2.146 2.382 0 4.643-.604 6.784-1.783v4.685c-.965.574-1.99.967-3.075 1.21-1.086.271-2.412.392-3.95.392zm21.829-.453h-5.367V43.688h5.367v35.607zm8.593 11.244c-1.598 0-2.955-.181-4.01-.574v-4.262a12.3 12.3 0 003.166.423c2.291 0 3.437-1.3 3.437-3.9v-28.26h5.367V82.59c0 2.6-.694 4.595-2.05 5.925-1.387 1.36-3.347 2.025-5.91 2.025zm2.261-43.254c0-.968.272-1.693.784-2.207.513-.514 1.266-.786 2.261-.786.935 0 1.689.272 2.201.786.513.514.784 1.27.784 2.207 0 .906-.271 1.632-.784 2.176-.512.514-1.266.786-2.2.786-.965 0-1.72-.272-2.262-.786-.543-.544-.784-1.27-.784-2.176zm33.8 24.816c0 2.478-.905 4.352-2.684 5.682-1.81 1.33-4.372 1.965-7.719 1.965-3.377 0-6.06-.514-8.11-1.541v-4.655c2.954 1.36 5.728 2.055 8.291 2.055 3.287 0 4.945-.997 4.945-2.992 0-.635-.181-1.18-.543-1.602-.362-.424-.965-.877-1.809-1.33-.844-.454-1.99-.968-3.497-1.542-2.895-1.118-4.885-2.267-5.91-3.385-1.025-1.119-1.538-2.6-1.538-4.383 0-2.177.875-3.839 2.623-5.048 1.75-1.21 4.101-1.783 7.116-1.783 2.955 0 5.759.604 8.412 1.813l-1.749 4.05c-2.713-1.118-5.005-1.692-6.874-1.692-2.834 0-4.251.816-4.251 2.418 0 .786.362 1.45 1.115 2.025.724.544 2.352 1.3 4.824 2.267 2.08.816 3.588 1.542 4.553 2.207.935.665 1.628 1.45 2.11 2.327.453.847.694 1.904.694 3.144z"/><path d="M58.176 117.864C30.678 115.416 9.03 92.171 9.03 63.97c0-28.202 21.648-51.416 49.146-53.864V4.03C27.332 6.51 3 32.443 3 64s24.332 57.491 55.176 59.97v-6.106zM67.824 4.03v6.076C95.322 12.554 116.97 35.798 116.97 64c0 28.202-21.648 51.446-49.146 53.894v6.076C98.668 121.49 123 95.557 123 64S98.668 6.509 67.824 4.03z" stroke="#96CA4B" stroke-width="6"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 128 128"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="clojurescript-plain.svg"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="748"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="4.53125"
+     inkscape:cx="64"
+     inkscape:cy="64"
+     inkscape:window-x="-6"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
+  <g
+     fill="#96CA4B"
+     id="g6">
+    <path
+       d="M35.563 79.748c-3.83 0-6.724-1.118-8.714-3.355-1.99-2.237-2.985-5.44-2.985-9.612 0-4.262 1.025-7.527 3.106-9.824 2.08-2.297 5.065-3.446 9.015-3.446 2.653 0 5.065.484 7.176 1.481l-1.628 4.323c-2.262-.877-4.131-1.33-5.608-1.33-4.372 0-6.543 2.902-6.543 8.705 0 2.841.543 4.957 1.628 6.408 1.085 1.42 2.683 2.146 4.794 2.146 2.382 0 4.643-.604 6.784-1.783v4.685c-.965.574-1.99.967-3.075 1.21-1.086.271-2.412.392-3.95.392zm21.829-.453h-5.367V43.688h5.367v35.607zm8.593 11.244c-1.598 0-2.955-.181-4.01-.574v-4.262a12.3 12.3 0 003.166.423c2.291 0 3.437-1.3 3.437-3.9v-28.26h5.367V82.59c0 2.6-.694 4.595-2.05 5.925-1.387 1.36-3.347 2.025-5.91 2.025zm2.261-43.254c0-.968.272-1.693.784-2.207.513-.514 1.266-.786 2.261-.786.935 0 1.689.272 2.201.786.513.514.784 1.27.784 2.207 0 .906-.271 1.632-.784 2.176-.512.514-1.266.786-2.2.786-.965 0-1.72-.272-2.262-.786-.543-.544-.784-1.27-.784-2.176zm33.8 24.816c0 2.478-.905 4.352-2.684 5.682-1.81 1.33-4.372 1.965-7.719 1.965-3.377 0-6.06-.514-8.11-1.541v-4.655c2.954 1.36 5.728 2.055 8.291 2.055 3.287 0 4.945-.997 4.945-2.992 0-.635-.181-1.18-.543-1.602-.362-.424-.965-.877-1.809-1.33-.844-.454-1.99-.968-3.497-1.542-2.895-1.118-4.885-2.267-5.91-3.385-1.025-1.119-1.538-2.6-1.538-4.383 0-2.177.875-3.839 2.623-5.048 1.75-1.21 4.101-1.783 7.116-1.783 2.955 0 5.759.604 8.412 1.813l-1.749 4.05c-2.713-1.118-5.005-1.692-6.874-1.692-2.834 0-4.251.816-4.251 2.418 0 .786.362 1.45 1.115 2.025.724.544 2.352 1.3 4.824 2.267 2.08.816 3.588 1.542 4.553 2.207.935.665 1.628 1.45 2.11 2.327.453.847.694 1.904.694 3.144z"
+       id="path2" />
+    <g
+       id="path4"
+       style="opacity:1">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#96ca4b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1.0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;"
+         d="M 58.176,117.864 C 30.678,115.416 9.03,92.171 9.03,63.97 9.03,35.768 30.678,12.554 58.176,10.106 V 4.03 C 27.332,6.51 3,32.443 3,64 3,95.557 27.332,121.491 58.176,123.97 Z M 67.824,4.03 v 6.076 C 95.322,12.554 116.97,35.798 116.97,64 c 0,28.202 -21.648,51.446 -49.146,53.894 v 6.076 C 98.668,121.49 123,95.557 123,64 123,32.443 98.668,6.509 67.824,4.03 Z"
+         id="path845" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#96ca4b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1.0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;"
+         d="M 61.175781 0.77929688 L 57.935547 1.0390625 C 25.551802 3.6428651 9.4739031e-15 30.900902 0 64 C 2.4842163e-15 97.099098 25.551675 124.35817 57.935547 126.96094 L 61.175781 127.2207 L 61.175781 115.11914 L 58.441406 114.875 C 32.475653 112.56341 12.029297 90.636438 12.029297 63.970703 C 12.029297 37.303913 32.473424 15.405541 58.441406 13.09375 L 61.175781 12.851562 L 61.175781 0.77929688 z M 64.824219 0.77929688 L 64.824219 4.0292969 L 64.824219 12.851562 L 67.558594 13.09375 C 93.524419 15.405349 113.9707 37.33321 113.9707 64 C 113.9707 90.66679 93.524419 112.59465 67.558594 114.90625 L 64.824219 115.14844 L 64.824219 127.2207 L 68.064453 126.96094 C 100.4482 124.35713 126 97.099098 126 64 C 126 30.900902 100.44833 3.6418254 68.064453 1.0390625 L 64.824219 0.77929688 z M 55.175781 7.4375 L 55.175781 7.4941406 C 27.469262 11.332796 6.0292969 35.180404 6.0292969 63.970703 C 6.0292969 92.760087 27.467373 116.63394 55.175781 120.47461 L 55.175781 120.5625 C 27.435322 116.7165 6 92.893003 6 64 C 6 35.106997 27.435211 11.284292 55.175781 7.4375 z M 70.824219 7.4375 C 98.564678 11.283501 120 35.106997 120 64 C 120 92.893003 98.564789 116.71571 70.824219 120.5625 L 70.824219 120.50586 C 98.532567 116.66525 119.9707 92.790299 119.9707 64 C 119.9707 35.209701 98.532567 11.334749 70.824219 7.4941406 L 70.824219 7.4375 z "
+         id="path847" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Update the `clojurescript-plain` icon as seen in #788. You can also view the new peek-bot's report on this icon [here](https://github.com/Thomas-Boi/devicon/pull/59).