### PR TITLE
new icon: markdown (original)

### DIFF
--- a/icons/markdown/markdown-original.svg
+++ b/icons/markdown/markdown-original.svg
@@ -1,1 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128"><path d="M11.95 29.12h104.1c3.23 0 5.847 2.645 5.847 5.911V92.97c0 3.266-2.617 5.912-5.846 5.912H11.949c-3.229 0-5.846-2.646-5.846-5.912V35.03c0-3.266 2.617-5.912 5.846-5.912zm0 0" fill="none" stroke="#000" stroke-width="9.541"/><path d="M20.721 84.1V43.9H32.42l11.697 14.78L55.81 43.9h11.696v40.2H55.81V61.044l-11.694 14.78-11.698-14.78V84.1H20.722zm73.104 0L76.28 64.591h11.697V43.9h11.698V64.59h11.698zm0 0"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="markdown-original.svg"
+   inkscape:version="1.0.2-2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="748"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="4.53125"
+     inkscape:cx="64"
+     inkscape:cy="64"
+     inkscape:window-x="-6"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 11.949219 24.347656 C 6.1140985 24.347656 1.3320312 29.21494 1.3320312 35.029297 L 1.3320312 92.970703 C 1.3320313 98.78506 6.1140985 103.65234 11.949219 103.65234 L 116.05078 103.65234 C 121.8859 103.65234 126.66797 98.78506 126.66797 92.970703 L 126.66797 35.03125 C 126.66797 29.216893 121.88511 24.349609 116.05078 24.349609 L 14.898438 24.349609 L 14.896484 24.347656 L 11.949219 24.347656 z M 11.943359 33.890625 L 11.949219 33.890625 L 116.05078 33.890625 C 116.67645 33.890625 117.12695 34.313607 117.12695 35.03125 L 117.12695 92.970703 C 117.12695 93.688347 116.67366 94.111328 116.05078 94.111328 L 11.949219 94.111328 C 11.326339 94.111328 10.873047 93.688347 10.873047 92.970703 L 10.873047 35.029297 C 10.873047 34.314327 11.324067 33.893769 11.943359 33.890625 z "
+     id="path2" />
+  <path
+     d="M20.721 84.1V43.9H32.42l11.697 14.78L55.81 43.9h11.696v40.2H55.81V61.044l-11.694 14.78-11.698-14.78V84.1H20.722zm73.104 0L76.28 64.591h11.697V43.9h11.698V64.59h11.698zm0 0"
+     id="path4" />
+</svg>


### PR DESCRIPTION
Removed strokes from `markdown-original`. This should be the last SVG that has strokes in them.

EDIT: You can view the new peek-bot result [here](https://github.com/Thomas-Boi/devicon/pull/66)