### PR TITLE
New Feature: webpage now displays <img> of SVG

### DIFF
--- a/docs/assets/js/script.js
+++ b/docs/assets/js/script.js
@@ -88,6 +88,7 @@ devicon.controller('IconListCtrl', function($scope, $http, $compile) {
     $scope.selectedFontIcon = $scope.icons[0].font[0];
     $scope.selectedSvgIcon = $scope.selectSvg($scope.icons[0].svg[0], 0);
     $scope.selectedFontIndex = 0;
+    $scope.selectedSvgIndex = 0;
 
     /*------ End of "Re-format devicon.json" ------*/
   });
@@ -101,6 +102,7 @@ devicon.controller('IconListCtrl', function($scope, $http, $compile) {
     $scope.selectedFontIcon = icon.font[0];
     $scope.selectedFontIndex = 0;
     $scope.selectedSvgIcon = $scope.selectSvg(icon.svg[0], 0);
+    $scope.selectedSvgIndex = 0;
 
     // reset color
     $scope.fontBackground = DEFAULT_BACKGROUND;
@@ -154,6 +156,7 @@ devicon.controller('IconListCtrl', function($scope, $http, $compile) {
       }
     });
   }
+
   /*---- End of "Change selected svg icon" ----*/
 });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,13 +66,16 @@
               </li>
             </div>
           </ul>
+          <p>Put this in your header</p>
           <div class="cde">
-            <div class="cde-com">&lt;!-- in your header --&gt;</div>
-            &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@{{ latestReleaseTagging }}/devicon.min.css"&gt;<br />
-            <br />
-            <div class="cde-com">&lt;!-- in your body --&gt;</div>
+            &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@{{ latestReleaseTagging }}/devicon.min.css"&gt;
+          </div>
+
+          <p>Use this in your body</p>
+          <div class="cde">
             &lt;i class="devicon-{{selectedIcon.name}}-{{selectedFontIcon}}<span ng-if="colored"> colored</span>"&gt;&lt;/i&gt;<br />
           </div>
+          <p><i>*Change the element's <code>font-size</code> to change the size of the icon</i></p>
         </li>
         <li>
           <h4>SVG versions <input type='color' value='#60be86' ng-model="svgBackground"></h4>
@@ -81,10 +84,18 @@
               <img ng-src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{{selectedIcon.name}}/{{selectedIcon.name}}-{{svgVersion}}.svg">
             </li>
           </ul>
+          <p>Using &lt;img&gt; element</p>
           <div class="cde">
-          &lt;svg viewBox="0 0 128 128"&gt;<br />
-          <div class="cde-ind">{{selectedSvgIcon}}</div>
-          &lt;/svg&gt;
+            &lt;img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{{selectedIcon.name}}/{{selectedIcon.name}}-{{selectedIcon.svg[selectedSvgIndex]}}.svg" /&gt;<br />
+          </div>
+
+          <br />
+
+          <p>Using Pure SVG</p>
+          <div class="cde">
+            &lt;svg viewBox="0 0 128 128"&gt;<br />
+            <div class="cde-ind">{{selectedSvgIcon}}</div>
+            &lt;/svg&gt;
           </div>
         </li>
       </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@
           <div class="cde">
             &lt;i class="devicon-{{selectedIcon.name}}-{{selectedFontIcon}}<span ng-if="colored"> colored</span>"&gt;&lt;/i&gt;<br />
           </div>
-          <p><i>*Change the element's <code>font-size</code> to change the size of the icon</i></p>
+          <p><i>*To change the size, change the <code>i</code>'s <code>font-size</code></i></p>
         </li>
         <li>
           <h4>SVG versions <input type='color' value='#60be86' ng-model="svgBackground"></h4>
@@ -88,6 +88,7 @@
           <div class="cde">
             &lt;img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/{{selectedIcon.name}}/{{selectedIcon.name}}-{{selectedIcon.svg[selectedSvgIndex]}}.svg" /&gt;<br />
           </div>
+          <p><i>*To change the size, change the <code>img</code>'s <code>height</code> and <code>width</code></i></p>
 
           <br />
 
@@ -97,6 +98,7 @@
             <div class="cde-ind">{{selectedSvgIcon}}</div>
             &lt;/svg&gt;
           </div>
+          <p><i>*To change the size, change the <code>svg</code>'s <code>height</code> and <code>width</code></i></p>
         </li>
       </ul>
 


### PR DESCRIPTION
# **New feature section**

<!-- If you are adding a new feature, follow the steps listed here, and delete the **New icon** section above. -->

## Double check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] PR does not match another non-stale PR currently opened
- [x] PR name matches the format *New Feature: a brief description of feature*

## This PR adds/fixes
Adds a section to display the `<img>` of the selected SVG to the website. 

This offers users an option to link external SVGs rather than using inline/pure SVGs. This will change dynamically depending on the currently selected SVGs.

I've tested the feature and here's what it looks like:

![image](https://user-images.githubusercontent.com/43018778/132135691-43257d1f-29b2-4b14-9e9d-9910cbb68a8b.png)

![image](https://user-images.githubusercontent.com/43018778/132135702-64b662e4-9201-4347-8c5f-806bb3eb417d.png)

The feature above was inspired by [this site](https://renevds.github.io/language-icon-widget-pages/#/) which was submitted by @renevds on Discord.

Also redo the icon section and add a hint on how to increase the icon's size:
![image](https://user-images.githubusercontent.com/43018778/132135734-b91cefd8-9a82-44eb-8a27-d7ddb9295963.png)


<!-- List your features here and the benefits they bring. -->

## Notes

<!-- List anything note-worthy here (potential issues, this needs to be merged to `develop` before working, etc.). -->
Later on, I'll work on a copy button to make things easier for the user. That'll be in a separate PR.