### PR TITLE
New Feature: Run Repository Dispatch for the React Repo on a NPM Release

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -21,3 +21,8 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+      - name: Dispatch React Release
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REACT_REPO_ACCESS_TOKEN }}
+          event-type: publish


### PR DESCRIPTION
# **New feature section**

<!-- If you are adding a new feature, follow the steps listed here, and delete the **New icon** section above. -->

## Double check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] PR does not match another non-stale PR currently opened
- [x] PR name matches the format *New Feature: a brief description of feature*

## This PR adds/fixes

This PR adds another step in the `npm_publish.yml` workflow to run a [repository dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch) to the react-devicons repo.

## Notes

To make this work, the environment variable `REACT_REPO_ACCESS_TOKEN` needs to be set to give the workflow access to the react repo. See more here: https://github.com/peter-evans/repository-dispatch