### PR TITLE
fix: add `original-wordmark` aliases for Liquibase

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -7193,6 +7193,11 @@
             {
                 "base": "original",
                 "alias": "plain"
+            },
+
+            {
+                "base": "original-wordmark",
+                "alias": "plain-wordmark"
             }
         ]
     }

--- a/devicon.json
+++ b/devicon.json
@@ -7194,7 +7194,6 @@
                 "base": "original",
                 "alias": "plain"
             },
-
             {
                 "base": "original-wordmark",
                 "alias": "plain-wordmark"


### PR DESCRIPTION
Things added/changed:

- Add `original-wordmark` aliases for Liquibase.
  - Thanks to @kilian-paquier for spotting the bug!
