### PR TITLE
fix: remove duplicate `tauri` icon entry

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -8580,31 +8580,6 @@
         "aliases": []
     },
     {
-        "name": "tauri",
-        "altnames": [],
-        "tags": [
-            "nodejs",
-            "rust",
-            "desktop",
-            "framework",
-            "programming"
-        ],
-        "versions": {
-            "svg": [
-                "original",
-                "original-wordmark",
-                "plain",
-                "plain-wordmark"
-            ],
-            "font": [
-                "plain",
-                "plain-wordmark"
-            ]
-        },
-        "color": "#FFC131",
-        "aliases": []
-    },
-    {
         "name": "tensorflow",
         "altnames": [],
         "tags": [


### PR DESCRIPTION
### Small Fixing

Maybe it's duplicated. `tauri`. So, I try to remove one 🙏!
https://github.com/devicons/devicon/blob/4f550268010eaf18b7713de5ee1fd94eb5959d16/devicon.json#L8558-L8606
