### PR TITLE
Update and use Geckodriver for Linux64

### DIFF
--- a/.github/workflows/build_icons.yml
+++ b/.github/workflows/build_icons.yml
@@ -3,11 +3,10 @@ on: workflow_dispatch
 jobs:
   build:
     name: Get Fonts From Icomoon
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with: 
           python-version: 3.8
 
@@ -18,12 +17,12 @@ jobs:
           npm install
 
       - name: Executing build and create fonts via icomoon
-        shell: cmd
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
           python ./.github/scripts/icomoon_build.py 
-          ./.github/scripts/build_assets/geckodriver-v0.30.0-win64/geckodriver.exe ./icomoon.json 
+          ./.github/scripts/build_assets/geckodriver-v0.32.1-linux64/geckodriver ./icomoon.json 
           ./devicon.json ./icons ./ %GITHUB_TOKEN% --headless
 
       - name: Upload geckodriver.log for debugging purposes

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "devicon.min.css",
   "scripts": {
     "build-css": "gulp updateCss && gulp clean",
-    "peek-test": "python ./.github/scripts/icomoon_peek.py ./.github/scripts/build_assets/geckodriver-v0.27.0-win64/geckodriver.exe ./icomoon.json ./devicon.json ./icons ./  --pr_title \"%PR_TITLE%\"",
-    "build-test": "python ./.github/scripts/icomoon_build.py ./.github/scripts/build_assets/geckodriver-v0.27.0-win64/geckodriver.exe ./icomoon.json ./devicon.json ./icons ./",
+    "peek-test": "python ./.github/scripts/icomoon_peek.py ./.github/scripts/build_assets/geckodriver-v0.32.1-linux64/geckodriver ./icomoon.json ./devicon.json ./icons ./  --pr_title \"%PR_TITLE%\"",
+    "build-test": "python ./.github/scripts/icomoon_build.py ./.github/scripts/build_assets/geckodriver-v0.32.1-linux64/geckodriver ./icomoon.json ./devicon.json ./icons ./",
     "optimize-svg": "gulp optimizeSvg",
     "bump": "gulp bumpVersion"
   },


### PR DESCRIPTION
Things added/changed:

- Update and use Geckodriver for Linux64.
  - We might want to make sure the newest Geckodriver version works. If it doesn't, we can always revert back to the other version.
  - The Windows build is kept in the `build_assets` folder in case it's needed again. If wanted, we can delete it.
