### PR TITLE
Update codeql-analysis to run on .github

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,56 +6,80 @@ on:
   pull_request:
     branches: [master, develop]
   schedule:
-    #        ┌───────────── minute (0 - 59)
-    #        │  ┌───────────── hour (0 - 23)
-    #        │  │ ┌───────────── day of the month (1 - 31)
-    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    #        │  │ │ │ │
-    #        │  │ │ │ │
-    #        │  │ │ │ │
-    #        *  * * * *
-    - cron: '30 1 * * 0'
+    - cron: 30 1 * * 0 # Runs every Sunday 1:30 am UTC
 
 jobs:
-  CodeQL-Build:
-    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+  CodeQL-Javascript:
     runs-on: ubuntu-latest
-
     permissions:
-      # required for all workflows
       security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: javascript
 
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+
+  CodeQL-Python-dot-github:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Initializes the CodeQL tools for scanning.
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        id: setup-python
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f ${{ github.workspace }}/.github/scripts/requirements.txt ];
+          then pip install -r ${{ github.workspace }}/.github/scripts/requirements.txt;
+          fi
+          # Set the `CODEQL-PYTHON` environment variable to the Python executable
+          # that includes the dependencies
+          echo "CODEQL_PYTHON=${{ steps.setup-python.outputs.python-path }}" >> $GITHUB_ENV
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
-        # Override language selection by uncommenting this and choosing your languages
         with:
-          languages: javascript, python
-
-      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below).
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following
-      #    three lines and modify them (or add more) to build your code if your
-      #    project uses a compiled language
-
-      #- run: |
-      #     make bootstrap
-      #     make release
+          languages: python
+          setup-python-dependencies: false
+          source-root: .github/
 
       - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+
+  CodeQL-Python-rest:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Find Python files outside the .github folder
+        id: find_files
+        run: |
+          python_files=$(find ${{ github.workspace }} -name "*.py" -type f -not -path '*/\.*' | wc -l)
+          echo "python_files=${python_files}" >> $GITHUB_OUTPUT
+          echo "$python_files Python files were found outside the .github folder."
+
+      - name: Initialize CodeQL
+        if: ${{ steps.find_files.outputs.python_files != '0' }}
+        uses: github/codeql-action/init@v2
+        with:
+          languages: python
+
+      - name: Perform CodeQL Analysis
+        if: ${{ steps.find_files.outputs.python_files != '0' }}
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
## Double-check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- x] PR does not match another non-stale PR currently opened

## Features
<!-- List your features here and the benefits they bring. Include images/codes as appropriate -->

It appears that by default codeql does not look into the `.github` directory, and as a result, all executions fail as python is listed, but no `.py` scripts exist outside that hidden directory.

To address this, this PR splits the codeql initialization and analysis into three parallel jobs, one for javascript, one for python that runs in `.github/`, one optional python for the rest in case we later add python scripts outside the `.github/` directory.

Here are some screenshots from the testing:

### Successful execution of all codeql analysis jobs.
![image](https://github.com/devicons/devicon/assets/338764/d6d2e332-bb46-49c1-be49-353320fce81c)

### Log that shows that the Python is skipped since there are no files there
![image](https://github.com/devicons/devicon/assets/338764/f9c9851f-a3f6-4d1d-a01e-bb774ca258a3)


**This PR closes NONE**

## Notes
<!-- List anything note-worthy here (potential issues, this needs to be merged to `master` before working, etc.). -->
