### PR TITLE
Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/check_icon_pr.yml
+++ b/.github/workflows/check_icon_pr.yml
@@ -32,7 +32,7 @@ jobs:
         run: python ./.github/scripts/check_icon_pr.py "$PR_TITLE" ./icons ./devicon.json
 
       - name: Upload the err messages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: err_messages
@@ -46,7 +46,7 @@ jobs:
         run: echo $PR_NUM > pr_num.txt
 
       - name: Upload the pr num
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: pr_num

--- a/.github/workflows/in_develop_labeler_preflight.yml
+++ b/.github/workflows/in_develop_labeler_preflight.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo $PR_NUM > pr_num.txt
 
       - name: Upload the PR number
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         with:
           name: pr_num
           path: ./pr_num.txt

--- a/.github/workflows/peek_icons.yml
+++ b/.github/workflows/peek_icons.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo $PR_NUM > pr_num.txt
 
       - name: Upload the PR number
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@4
         with:
           name: pr_num
           path: ./pr_num.txt
@@ -45,21 +45,21 @@ jobs:
           ./devicon.json ./icons ./ --headless "$PR_TITLE"
 
       - name: Upload the err messages (created by icomoon_peek.py)
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: err_messages
           path: ./err_messages.txt
 
       - name: Upload screenshots for comments
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         if: success()
         with:
           name: screenshots
           path: ./screenshots/*.png
 
       - name: Upload geckodriver.log for debugging purposes
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: geckodriver-log


### PR DESCRIPTION
## Double check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] PR does not match another non-stale PR currently opened

## Features
<!-- List your features here and the benefits they bring. Include images/codes if appropriate -->

Fix GitHub Action workflows failing due to newly deprecated [actions/upload-artifact](https://github.com/actions/upload-artifact) v3. Example of failing pipeline: https://github.com/devicons/devicon/actions/runs/13191480278/job/36825288540?pr=2343

See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Notes

Migration steps to v4 can be found here: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

I don't think any of the breaking changes apply to this repo.