### PR TITLE
build(npm): automatically run build-icons for correct os

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,10 @@ https://www.python.org/downloads/
 > **Note**
 > Make sure your Python install includes [pip](https://pypi.org/project/pip/)
 
-<h3>Install Selenium</h3>
+<h3>Install Dependencies</h3>
 
 ```bash
-python3 -m pip install --upgrade pip && pip install selenium==4.1.0 requests==2.25.1
+python -m pip install -r ./.github/scripts/requirements.txt
 ```
 
 <h3 id="building-icons">Build the new icons</h3>
@@ -281,11 +281,7 @@ python3 -m pip install --upgrade pip && pip install selenium==4.1.0 requests==2.
 Usually, this is done on each release, but you can have a sneak peek before a release.</p>
 
 ```bash
-# Linux/Unix
 npm run build-icons
-
-# Windows
-python3 ./.github/scripts/icomoon_build_githubless.py ./.github/scripts/build_assets/geckodriver-v0.32.2-win64/geckodriver.exe ./icomoon.json ./devicon.json ./icons ./ --headless
 ```
 
 <i>The process might take a while, depending on your operating system's speed and the amount of icons.</i>
@@ -311,7 +307,7 @@ npm run dev # Will run on port 8000
 <p>Or this command, which does exactly the same, but the port can be customized.</p>
 
 ```bash
-python3 -m http.server <port>
+python -m http.server <port>
 ```
 
 <p>You're done now! :tada: Your build of Devicons should be available at <code>https://localhost:8000</code> (or the desired port).</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "gulp-sass": "^5.0.0",
                 "gulp-svgmin": "^3.0.0",
                 "open": "^10.0.3",
+                "run-script-os": "^1.1.6",
                 "sass": "^1.26.10",
                 "yargs": "^17.0.0"
             }
@@ -4188,6 +4189,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/run-script-os": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+            "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "run-os": "index.js",
+                "run-script-os": "index.js"
             }
         },
         "node_modules/rxjs": {
@@ -8698,6 +8710,12 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
             "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+            "dev": true
+        },
+        "run-script-os": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+            "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
             "dev": true
         },
         "rxjs": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
         "peek-test": "python ./.github/scripts/icomoon_peek.py ./.github/scripts/build_assets/geckodriver-v0.32.2-linux64/geckodriver ./icomoon.json ./devicon.json ./icons ./  --pr_title \"$PR_TITLE\"",
         "optimize-svg": "gulp optimizeSvg",
         "bump": "gulp bumpVersion",
-        "build-icons": "python3 ./.github/scripts/icomoon_build_githubless.py ./.github/scripts/build_assets/geckodriver-v0.32.2-linux64/geckodriver ./icomoon.json ./devicon.json ./icons ./ --headless",
+        "build-icons": "run-script-os",
+        "build-icons:linux:macOS": "python ./.github/scripts/icomoon_build_githubless.py ./.github/scripts/build_assets/geckodriver-v0.32.2-linux64/geckodriver ./icomoon.json ./devicon.json ./icons ./ --headless",
+        "build-icons:windows": "python ./.github/scripts/icomoon_build_githubless.py ./.github/scripts/build_assets/geckodriver-v0.32.2-win64/geckodriver.exe ./icomoon.json ./devicon.json ./icons ./ --headless",
+        "build-icons:default": "echo 'Unsupported OS' && exit 1",
         "dev": "concurrently \"npm:open-browser\" \"npm:start-local-server\"",
-        "start-local-server": "python3 -m http.server 8000",
+        "start-local-server": "python -m http.server 8000",
         "open-browser": "node -e \"import('open').then(pkg => pkg.default('http://localhost:8000/docs'))\""
     },
     "repository": {
@@ -36,6 +39,7 @@
         "gulp-sass": "^5.0.0",
         "gulp-svgmin": "^3.0.0",
         "open": "^10.0.3",
+        "run-script-os": "^1.1.6",
         "sass": "^1.26.10",
         "yargs": "^17.0.0"
     }


### PR DESCRIPTION
## Double check these details before you open a PR

<!-- Tick the checkboxes to ensure you've done everything correctly -->
- [x] PR does not match another non-stale PR currently opened

## Features
<!-- List your features here and the benefits they bring. Include images/codes if appropriate -->
This PR makes it so `npm run build-icons` works on all standard OSes.

**This PR closes NONE**
<!-- List issues that this PR would close above. Ex: This PR closes #1, #2, #3. -->
<!-- If your pull request does not fix any issue, it's best to make an issue OR remove this section, depending on your changes. -->

## Notes
<!-- List anything note-worthy here (potential issues, this needs to be merged to `master` before working, etc.). -->
A new dev dependency was added to simplify this: https://www.npmjs.com/package/run-script-os

Edit: This is draft as I discovered it is not using the activated python venv. Will update once resolved.