### PR TITLE
Add missing alias definitions for C (original-wordmark, plain, plain-wordmark)

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -1544,7 +1544,15 @@
         "color": "#a9bacd",
         "aliases": [
             {
-                "base": "plain",
+                "base": "original",
+                "alias": "original-wordmark"
+            },
+            {
+                "base": "original",
+                "alias": "plain"
+            },
+            {
+                "base": "original",
                 "alias": "plain-wordmark"
             },
             {


### PR DESCRIPTION
fixes the following draft-release issue:


## 🔧 c
[Icon Folder](https://github.com/devicons/devicon/tree/develop/icons/c)

**Issues:**
- ❌ `plain` is used as alias base but is not in `versions.svg`.

![image](https://github.com/user-attachments/assets/ab94e407-6ecb-4e81-819e-a8c52e69f80b)
