### PR TITLE
new icon: claudecode (original)

### DIFF
--- a/devicon.json
+++ b/devicon.json
@@ -2068,7 +2068,7 @@
             ],
             "font": []
         },
-        "color": "#C4F9FF",
+        "color": "#d97757",
         "aliases": []
     },
     {

--- a/devicon.json
+++ b/devicon.json
@@ -2055,6 +2055,23 @@
         "aliases": []
     },
     {
+        "name": "claudecode",
+        "altnames": [],
+        "tags": [
+            "ai",
+            "coding",
+            "assistant"
+        ],
+        "versions": {
+            "svg": [
+                "original"
+            ],
+            "font": []
+        },
+        "color": "#C4F9FF",
+        "aliases": []
+    },
+    {
         "name": "clickhouse",
         "altnames": [],
         "tags": [

--- a/icons/claudecode/claudecode-original.svg
+++ b/icons/claudecode/claudecode-original.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><path fill="#d97757" fill-rule="evenodd" d="M108.99 56.245H124v15.51h-15v15.14h-7.435V101.5H94V86.895h-7.435V101.5H79V86.895H49V101.5h-7.56V86.895H34V101.5h-7.565V86.895H19V71.75H4v-15.5h15V26.5h89.99Zm-74.99 0h7.44V42.01H34Zm52.55 0H94V42.01h-7.45z" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
## Summary
Adds the Claude Code icon to the devicons library. Claude Code is an AI coding assistant that accelerates development workflows.

## What Changed
- Added `claudecode-original.svg` to `icons/claudecode/`
- Updated `devicon.json` to include the claudecode entry

## Changelog
- Added claudecode icon (original version)

## References
- Follows [contributing guidelines](https://github.com/devicons/devicon/blob/master/CONTRIBUTING.md)

## Checklist
- [x] Icons follow the project's naming conventions
- [x] SVG files use `0 0 128 128` viewbox
- [x] Icon is centered horizontally and vertically within the viewBox
- [x] Transparent background
- [x] Fills are used instead of strokes